### PR TITLE
make the bg image functionality work with Markdown generated HTML

### DIFF
--- a/template.hbs
+++ b/template.hbs
@@ -35,8 +35,6 @@ window.onload = function() {
         } else {
             body.style.backgroundImage = '';
             body.style.backgroundColor = e.style.backgroundColor;
-            body.style.backgroundSize = '';
-            body.style.backgroundPosition = '';
         }
         if (ti !== undefined) window.clearInterval(ti);
         t = parseInt(e.dataset.timeToNext || 0, 10);

--- a/template.hbs
+++ b/template.hbs
@@ -10,21 +10,33 @@
 <script type='text/javascript'>
 window.onload = function() {
     var s = document.getElementsByTagName('div'), cur = 0, ti;
+		var body = document.body;
+
     if (!s) return;
-    function go(n) {
-        cur = n;
+
+		function go(n) {
+				cur = n;
         var i = 1e3, e = s[n], t;
-        document.body.className = e.dataset.bodyclass || '';
-        for (var k = 0; k < s.length; k++) s[k].style.display = 'none';
-        e.style.display = 'inline';
+				body.className = e.dataset.bodyclass || '';
+
+				for (var k = 0; k < s.length; k++) s[k].style.display = 'none';
+
+				e.style.display = 'inline';
         e.style.fontSize = i + 'px';
-        if (e.firstChild && e.firstChild.nodeName === 'IMG') {
-            document.body.style.backgroundImage = 'url(' + e.firstChild.src + ')';
-            e.firstChild.style.display = 'none';
+
+				var secondChild = e.firstChild.firstChild;
+
+				if (secondChild && secondChild.nodeName === 'IMG') {
+
+            body.style.backgroundImage = 'url(' + secondChild.src + ')';
+            secondChild.style.display = 'none';
+
             if ('classList' in e) e.classList.add('imageText');
         } else {
-            document.body.style.backgroundImage = '';
-            document.body.style.backgroundColor = e.style.backgroundColor;
+            body.style.backgroundImage = '';
+            body.style.backgroundColor = e.style.backgroundColor;
+						body.style.backgroundSize = '';
+            body.style.backgroundPosition = '';
         }
         if (ti !== undefined) window.clearInterval(ti);
         t = parseInt(e.dataset.timeToNext || 0, 10);

--- a/template.hbs
+++ b/template.hbs
@@ -10,23 +10,23 @@
 <script type='text/javascript'>
 window.onload = function() {
     var s = document.getElementsByTagName('div'), cur = 0, ti;
-		var body = document.body;
+    var body = document.body;
 
     if (!s) return;
 
-		function go(n) {
-				cur = n;
+    function go(n) {
+        cur = n;
         var i = 1e3, e = s[n], t;
-				body.className = e.dataset.bodyclass || '';
+        body.className = e.dataset.bodyclass || '';
 
-				for (var k = 0; k < s.length; k++) s[k].style.display = 'none';
+        for (var k = 0; k < s.length; k++) s[k].style.display = 'none';
 
-				e.style.display = 'inline';
+        e.style.display = 'inline';
         e.style.fontSize = i + 'px';
 
-				var secondChild = e.firstChild.firstChild;
+        var secondChild = e.firstChild.firstChild;
 
-				if (secondChild && secondChild.nodeName === 'IMG') {
+        if (secondChild && secondChild.nodeName === 'IMG') {
 
             body.style.backgroundImage = 'url(' + secondChild.src + ')';
             secondChild.style.display = 'none';
@@ -35,7 +35,7 @@ window.onload = function() {
         } else {
             body.style.backgroundImage = '';
             body.style.backgroundColor = e.style.backgroundColor;
-						body.style.backgroundSize = '';
+            body.style.backgroundSize = '';
             body.style.backgroundPosition = '';
         }
         if (ti !== undefined) window.clearInterval(ti);


### PR DESCRIPTION
marked always puts `<p>` tags around the images so the script did not detect the image as the first child in the slide. my changes fix that so that the first image in the slide will be set as a background image just like it works in big with plain HTML.
